### PR TITLE
Blog posts: add admin UI and public actions

### DIFF
--- a/app/admin/blog_post.rb
+++ b/app/admin/blog_post.rb
@@ -1,13 +1,15 @@
-ActiveAdmin.register Page do
+ActiveAdmin.register BlogPost do
   form do |f|
+    f.object.posted_at = DateTime.now
     f.inputs do
       f.input :title, as: :string
       f.input :content
       f.input :slug, placeholder: 'Will be automatically generated if blank'
-      f.input :parent
+      f.input :author
+      f.input :posted_at
     end
     f.actions
   end
 
-  permit_params :title, :content, :slug, :parent
+  permit_params :title, :content, :slug, :author_id, :posted_at
 end

--- a/app/controllers/blog_posts_controller.rb
+++ b/app/controllers/blog_posts_controller.rb
@@ -1,7 +1,11 @@
 class BlogPostsController < ApplicationController
 
+  def index
+    @posts = BlogPost.all
+  end
+
   def show
-    raise params.inspect
+    @post = BlogPost.find_by_slug!(params[:slug])
   end
 
 end

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -18,6 +18,10 @@
 class Admin < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
-  devise :database_authenticatable, 
+  devise :database_authenticatable,
          :recoverable, :rememberable, :trackable, :validatable
+
+  def to_s
+    email
+  end
 end

--- a/app/models/blog_post.rb
+++ b/app/models/blog_post.rb
@@ -13,5 +13,7 @@
 #
 
 class BlogPost < ApplicationRecord
-  belongs_to :author, class_name: Admin
+  include HasSlug
+
+  belongs_to :author, class_name: 'Admin'
 end

--- a/app/models/concerns/has_slug.rb
+++ b/app/models/concerns/has_slug.rb
@@ -1,0 +1,15 @@
+module HasSlug
+  extend ActiveSupport::Concern
+
+  included do
+    before_validation :set_slug_if_empty
+
+    validates_presence_of :title, :slug
+  end
+
+  def set_slug_if_empty
+    if self.slug.empty?
+      self.slug = self.title.parameterize
+    end
+  end
+end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -13,5 +13,7 @@
 #
 
 class Page < ApplicationRecord
-  belongs_to :parent, class_name: Page, optional: true
+  include HasSlug
+
+  belongs_to :parent, class_name: 'Page', optional: true
 end

--- a/app/views/blog_posts/index.html.erb
+++ b/app/views/blog_posts/index.html.erb
@@ -1,0 +1,7 @@
+<% @posts.each do |post| %>
+  <article>
+    <h2><%= post.title %></h2>
+    <p><%= post.posted_at %></p>
+    <%= link_to 'Read more', blog_post_path(post.slug) %>
+  </article>
+<% end %>

--- a/app/views/blog_posts/show.html.erb
+++ b/app/views/blog_posts/show.html.erb
@@ -1,0 +1,5 @@
+<h1><%= @post.title %></h1>
+
+<p><%= @post.posted_at %></p>
+
+<%= @post.content %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,7 +27,9 @@
 
     <hr/ >
 
-    <h1>East Bay DSA</h1>
+    <h1>
+      <%= link_to 'East Bay DSA', root_path %>
+    </h1>
 
     <ul>
       <% @menu.each do |item| %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,8 @@ Rails.application.routes.draw do
   devise_for :admins, ActiveAdmin::Devise.config
   ActiveAdmin.routes(self)
 
-  get 'blog', to: 'blog#index'
-  get 'blog/*slug', to: 'blog#show'
+  get 'blog', to: 'blog_posts#index'
+  get 'blog/*slug', to: 'blog_posts#show', as: 'blog_post'
   get '*slug', to: 'pages#show'
   root to: "pages#home"
 end


### PR DESCRIPTION
Render blog posts at `/blog[/:slug]`, with admin UI for management.

Objects with URL slugs (pages, blog posts) now automatically generate
their slug from the object title if slug is left blank.

Fixes #3 