### PR TITLE
Set homepage banner and upload image.

### DIFF
--- a/app/admin/home.rb
+++ b/app/admin/home.rb
@@ -4,9 +4,11 @@ ActiveAdmin.register Home do
       f.input :intro, as: :trix_editor
       f.input :featured_page_1
       f.input :featured_page_2
+      f.input :featured_image, as: :file, :input_html => { :class => "s3_url" },
+          :hint => image_tag(f.object.featured_image, style: 'width:200px;height:auto;')
     end
     f.actions
   end
 
-  permit_params :intro, :featured_page_1_id, :featured_page_2_id
+  permit_params :intro, :featured_page_1_id, :featured_page_2_id, :featured_image
 end

--- a/app/admin/home.rb
+++ b/app/admin/home.rb
@@ -4,8 +4,10 @@ ActiveAdmin.register Home do
       f.input :intro, as: :trix_editor
       f.input :featured_page_1
       f.input :featured_page_2
-      f.input :featured_image, as: :file, :input_html => { :class => "s3_url" },
-          :hint => image_tag(f.object.featured_image, style: 'width:200px;height:auto;')
+      #f.input :featured_image, as: :file, :input_html => { :class => "s3_url" },
+      #    :hint => (image_tag(f.object.featured_image, style: 'width:200px;height:auto;') \
+      #              if f.object.featured_image?)
+      f.input :featured_image, as: :s3_url
     end
     f.actions
   end

--- a/app/admin/home.rb
+++ b/app/admin/home.rb
@@ -4,9 +4,6 @@ ActiveAdmin.register Home do
       f.input :intro, as: :trix_editor
       f.input :featured_page_1
       f.input :featured_page_2
-      #f.input :featured_image, as: :file, :input_html => { :class => "s3_url" },
-      #    :hint => (image_tag(f.object.featured_image, style: 'width:200px;height:auto;') \
-      #              if f.object.featured_image?)
       f.input :featured_image, as: :s3_url
     end
     f.actions

--- a/app/assets/javascripts/attachments.js
+++ b/app/assets/javascripts/attachments.js
@@ -32,9 +32,10 @@ function setupS3UrlField($form_element) {
     var file = $(this)[0].files[0];
     if (file) {
       $form_element.find('.s3_url_img').hide();
+      updateUploadProgressDisplay($form_element, 0);
       $form_element.find('.s3_url_loading').show();
       uploadFile(file, function(progress) {
-        console.log('upload progress: ' + progress);
+        updateUploadProgressDisplay($form_element, progress);
       }, function(url) {
         $form_element.find('.s3_url_original_input').val(url);
         var newImage = new Image();
@@ -46,6 +47,11 @@ function setupS3UrlField($form_element) {
       });
     }
   });
+}
+
+
+function updateUploadProgressDisplay($form_element, progress) {
+  $form_element.find('.s3_url_loading').text('Uploading... ' + parseInt(progress) + '%');
 }
 
 

--- a/app/assets/javascripts/attachments.js
+++ b/app/assets/javascripts/attachments.js
@@ -36,7 +36,7 @@ function setupS3UrlField($form_element) {
       uploadFile(file, function(progress) {
         console.log('upload progress: ' + progress);
       }, function(url) {
-        $form_element.find('#home_featured_image').val(url);
+        $form_element.find('.s3_url_original_input').val(url);
         var newImage = new Image();
         newImage.onload = function() {
           $form_element.find('.s3_url_loading').hide();
@@ -50,7 +50,7 @@ function setupS3UrlField($form_element) {
 
 
 function refreshImagePreview($form_element) {
-  var imgUrl = $form_element.find('#home_featured_image').val();
+  var imgUrl = $form_element.find('.s3_url_original_input').val();
   if (imgUrl) {
     $form_element.find('.s3_url_img').attr('src', imgUrl).show();
   }

--- a/app/assets/javascripts/attachments.js
+++ b/app/assets/javascripts/attachments.js
@@ -60,27 +60,27 @@ function refreshImagePreview($form_element) {
 function uploadFile(file, progressCallback, successCallback) {
   $.get('/admin/admins/get_presigned_url?filename=' + file.name, {}, function(uploadUrl) {
     $.ajax({
-        type: 'PUT',
-        url: uploadUrl,
-        data: file,
-        processData: false,
-        contentType: false,
-        error: function(xhr, textStatus, errorMsg) {
-          console.log(errorMsg);
-          alert('Failed to upload file: ' + textStatus + '. See the console for more detail.');
-        },
-        xhr: function() {
-          var xhr = $.ajaxSettings.xhr();
-          xhr.upload.onprogress = function(event) {
-            var progress = event.loaded / event.total * 100;
-            return progressCallback(progress);
-          };
-          return xhr;
-        },
-        success: function(data, msg, xhr) {
-          // Strip off the signing token and other params to leave the plain URL.
-          return successCallback(uploadUrl.substring(0, uploadUrl.lastIndexOf('?')));
-        }
+      type: 'PUT',
+      url: uploadUrl,
+      data: file,
+      processData: false,
+      contentType: false,
+      error: function(xhr, textStatus, errorMsg) {
+        console.log(errorMsg);
+        alert('Failed to upload file: ' + textStatus + '. See the console for more detail.');
+      },
+      xhr: function() {
+        var xhr = $.ajaxSettings.xhr();
+        xhr.upload.onprogress = function(event) {
+          var progress = event.loaded / event.total * 100;
+          return progressCallback(progress);
+        };
+        return xhr;
+      },
+      success: function(data, msg, xhr) {
+        // Strip off the signing token and other params to leave the plain URL.
+        return successCallback(uploadUrl.substring(0, uploadUrl.lastIndexOf('?')));
+      }
     });
   });
 }

--- a/app/assets/javascripts/attachments.js
+++ b/app/assets/javascripts/attachments.js
@@ -19,17 +19,6 @@ $(document).ready(function() {
     }
   });
 
-  $('input:file.s3_url').on('change', function(event) {
-    var file = $(this)[0].files[0];
-    if (file) {
-      uploadFile(file, function(progress) {
-        console.log('upload progress: ' + progress);
-      }, function(url) {
-        console.log('final url: ' + url);
-      });
-    }
-  });
-
   $('.s3_url').each(function(i, form_element) {
     setupS3UrlField($(form_element));
     refreshImagePreview($(form_element));
@@ -38,14 +27,22 @@ $(document).ready(function() {
 
 
 function setupS3UrlField($form_element) {
+  $form_element.find('.s3_url_loading').hide()
   $form_element.find('.s3_url_file').on('change', function() {
     var file = $(this)[0].files[0];
     if (file) {
+      $form_element.find('.s3_url_img').hide();
+      $form_element.find('.s3_url_loading').show();
       uploadFile(file, function(progress) {
         console.log('upload progress: ' + progress);
       }, function(url) {
-        console.log('final url: ' + url);
         $form_element.find('#home_featured_image').val(url);
+        var newImage = new Image();
+        newImage.onload = function() {
+          $form_element.find('.s3_url_loading').hide();
+          refreshImagePreview($form_element);
+        }
+        newImage.src = url;
       });
     }
   });
@@ -55,7 +52,7 @@ function setupS3UrlField($form_element) {
 function refreshImagePreview($form_element) {
   var imgUrl = $form_element.find('#home_featured_image').val();
   if (imgUrl) {
-    $form_element.find('.s3_url_img').attr('src', imgUrl);
+    $form_element.find('.s3_url_img').attr('src', imgUrl).show();
   }
 }
 

--- a/app/inputs/s3_url_input.rb
+++ b/app/inputs/s3_url_input.rb
@@ -3,6 +3,10 @@
 # If you use this input, make sure to include attachments.js as well.
 
 class S3UrlInput < Formtastic::Inputs::UrlInput
+  def input_html_options
+    super.merge(:class => 's3_url_original_input')
+  end
+
   def to_html
     file_input_cell = template.content_tag :td do
       builder.hidden_field(method, input_html_options) <<

--- a/app/inputs/s3_url_input.rb
+++ b/app/inputs/s3_url_input.rb
@@ -8,37 +8,30 @@ class S3UrlInput < Formtastic::Inputs::UrlInput
   end
 
   def to_html
-    file_input_cell = template.content_tag :td do
-      builder.hidden_field(method, input_html_options) <<
-      # file_field_tag requires an ID to be given for some reason. Just make sure
-      # it doesn't collide with anything else.
-      template.file_field_tag('attachment_' + SecureRandom.hex(4), class: 's3_url_file')
-    end
-
-    file_input_row = template.content_tag :tr do
-      file_input_cell
-    end
-
-    image_preview_cell = template.content_tag :td do
-      template.image_tag('', class: 's3_url_img', style: 'width:400px;height:auto;') <<
-      template.content_tag(:div, 'Uploading...', class: 's3_url_loading')
-    end
-
-    image_preview_row = template.content_tag :tr do
-      image_preview_cell
-    end
-
-    input_tbody = template.content_tag :tbody do
-      file_input_row << image_preview_row
-    end
-
-    input_table = template.content_tag :table, style: 'display:inline;' do
-      input_tbody
-    end
-
     input_wrapping do
-      label_html <<
-      input_table
+      label_html +
+
+      template.content_tag(:table, style: 'display:inline;') do
+        template.content_tag :tbody do
+
+          template.content_tag(:tr) {
+            template.content_tag :td do
+              builder.hidden_field(method, input_html_options) <<
+              # file_field_tag requires an ID to be given for some reason. Just make sure
+              # it doesn't collide with anything else.
+              template.file_field_tag('attachment_' + SecureRandom.hex(4), class: 's3_url_file')
+            end
+          } +
+
+          template.content_tag(:tr) {
+            template.content_tag :td do
+              template.image_tag('', class: 's3_url_img', style: 'width:400px;height:auto;') <<
+              template.content_tag(:div, 'Uploading...', class: 's3_url_loading')
+            end
+          }
+
+        end
+      end
     end
   end
 end

--- a/app/inputs/s3_url_input.rb
+++ b/app/inputs/s3_url_input.rb
@@ -1,0 +1,40 @@
+# Custom input for transparently uploading files to S3.
+# If you use this input, make sure to include attachments.js as well.
+
+class S3UrlInput < Formtastic::Inputs::UrlInput
+  def to_html
+
+    file_input_cell = template.content_tag :td do
+      builder.hidden_field(method, input_html_options) <<
+      # file_field_tag requires an ID to be given for some reason. Just make sure
+      # it doesn't collide with anything else.
+      template.file_field_tag('attachment_' + SecureRandom.hex(4), class: 's3_url_file')
+    end
+
+    file_input_row = template.content_tag :tr do
+      file_input_cell
+    end
+
+    image_preview_cell = template.content_tag :td do
+      template.image_tag('', class: 's3_url_img', style: 'width:200px;height:auto;')
+    end
+
+    image_preview_row = template.content_tag :tr do
+      image_preview_cell
+    end
+
+    input_tbody = template.content_tag :tbody do
+      file_input_row << image_preview_row
+    end
+
+    input_table = template.content_tag :table, style: 'display:inline;' do
+      input_tbody
+    end
+
+    input_wrapping do
+      label_html <<
+      input_table
+    end
+
+  end
+end

--- a/app/inputs/s3_url_input.rb
+++ b/app/inputs/s3_url_input.rb
@@ -1,9 +1,9 @@
 # Custom input for transparently uploading files to S3.
+# Hides the actual text field input in favor of a file selector and an image preview.
 # If you use this input, make sure to include attachments.js as well.
 
 class S3UrlInput < Formtastic::Inputs::UrlInput
   def to_html
-
     file_input_cell = template.content_tag :td do
       builder.hidden_field(method, input_html_options) <<
       # file_field_tag requires an ID to be given for some reason. Just make sure
@@ -36,6 +36,5 @@ class S3UrlInput < Formtastic::Inputs::UrlInput
       label_html <<
       input_table
     end
-
   end
 end

--- a/app/inputs/s3_url_input.rb
+++ b/app/inputs/s3_url_input.rb
@@ -26,7 +26,7 @@ class S3UrlInput < Formtastic::Inputs::UrlInput
           template.content_tag(:tr) {
             template.content_tag :td do
               template.image_tag('', class: 's3_url_img', style: 'width:400px;height:auto;') <<
-              template.content_tag(:div, 'Uploading...', class: 's3_url_loading')
+              template.content_tag(:div, 'Uploading... 0%', class: 's3_url_loading')
             end
           }
 

--- a/app/inputs/s3_url_input.rb
+++ b/app/inputs/s3_url_input.rb
@@ -16,7 +16,7 @@ class S3UrlInput < Formtastic::Inputs::UrlInput
     end
 
     image_preview_cell = template.content_tag :td do
-      template.image_tag('', class: 's3_url_img', style: 'width:200px;height:auto;') <<
+      template.image_tag('', class: 's3_url_img', style: 'width:400px;height:auto;') <<
       template.content_tag(:div, 'Uploading...', class: 's3_url_loading')
     end
 

--- a/app/inputs/s3_url_input.rb
+++ b/app/inputs/s3_url_input.rb
@@ -16,7 +16,8 @@ class S3UrlInput < Formtastic::Inputs::UrlInput
     end
 
     image_preview_cell = template.content_tag :td do
-      template.image_tag('', class: 's3_url_img', style: 'width:200px;height:auto;')
+      template.image_tag('', class: 's3_url_img', style: 'width:200px;height:auto;') <<
+      template.content_tag(:div, 'Uploading...', class: 's3_url_loading')
     end
 
     image_preview_row = template.content_tag :tr do

--- a/app/models/home.rb
+++ b/app/models/home.rb
@@ -8,6 +8,7 @@
 #  featured_page_2_id :integer
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
+#  featured_image     :string
 #
 
 class Home < ApplicationRecord

--- a/db/migrate/20171028163932_add_homepage_featured_image.rb
+++ b/db/migrate/20171028163932_add_homepage_featured_image.rb
@@ -1,0 +1,5 @@
+class AddHomepageFeaturedImage < ActiveRecord::Migration[5.1]
+  def change
+    add_column :homes, :featured_image, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171011191047) do
+ActiveRecord::Schema.define(version: 20171028163932) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -62,6 +62,7 @@ ActiveRecord::Schema.define(version: 20171011191047) do
     t.integer "featured_page_2_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "featured_image"
   end
 
   create_table "menu_items", force: :cascade do |t|

--- a/test/fixtures/homes.yml
+++ b/test/fixtures/homes.yml
@@ -8,6 +8,7 @@
 #  featured_page_2_id :integer
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
+#  featured_image     :string
 #
 
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html

--- a/test/models/home_test.rb
+++ b/test/models/home_test.rb
@@ -8,6 +8,7 @@
 #  featured_page_2_id :integer
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
+#  featured_image     :string
 #
 
 require 'test_helper'


### PR DESCRIPTION
Issue https://github.com/eastbaydsa/website/issues/37.

- Adds a new `featured_image` field for the homepage banner image.
- Adds a custom formtastic input for URL fields that should be uploaded to S3. Includes a preview image. A bit overkill here but it should make it trivial to turn other fields into image upload fields.