### PR TITLE
Admin usability improvements.

### DIFF
--- a/app/admin/blog_post.rb
+++ b/app/admin/blog_post.rb
@@ -1,4 +1,8 @@
 ActiveAdmin.register BlogPost do
+  controller do
+    defaults :finder => :find_by_slug
+  end
+
   index do
     column :title
     column :content do |post|
@@ -6,7 +10,25 @@ ActiveAdmin.register BlogPost do
     end
     column :posted_at
     column :author
+    column :direct_link do |post|
+      @url = url_for(post)
+      link_to(@url, @url, target: '_blank')
+    end
     actions
+  end
+
+  show do
+    attributes_table do
+      row :title
+      row :content do |post|
+        post.content.html_safe
+      end
+      columns_to_exclude = ["title", "content"]
+      (BlogPost.column_names - columns_to_exclude).each do |c|
+        row c.to_sym
+      end
+    end
+    active_admin_comments
   end
 
   form do |f|

--- a/app/admin/blog_post.rb
+++ b/app/admin/blog_post.rb
@@ -23,6 +23,10 @@ ActiveAdmin.register BlogPost do
       row :content do |post|
         post.content.html_safe
       end
+      row :direct_link do |post|
+        @url = url_for(post)
+        link_to(@url, @url, target: '_blank')
+      end
       columns_to_exclude = ["title", "content"]
       (BlogPost.column_names - columns_to_exclude).each do |c|
         row c.to_sym

--- a/app/admin/home.rb
+++ b/app/admin/home.rb
@@ -1,4 +1,39 @@
 ActiveAdmin.register Home do
+  index do
+    column :intro do |home|
+      strip_tags(home.intro)
+    end
+    column :featured_page_1
+    column :featured_page_2
+    column :featured_image do |home|
+      image_tag(home.featured_image, style: 'width:200px;height:auto;')
+    end
+    actions
+  end
+
+  show do
+    attributes_table do
+      row :intro do |home|
+        home.intro.html_safe
+      end
+      row :featured_image do |home|
+        image_tag(home.featured_image, style: 'width:200px;height:auto;')
+      end
+      row :featured_page_1 do |home|
+        link_to(home.featured_page_1.title, url_for(home.featured_page_1))
+      end
+      row :featured_page_2 do |home|
+        link_to(home.featured_page_2.title, url_for(home.featured_page_2))
+      end
+      columns_to_exclude = ["id", "intro", "featured_image",
+                            "featured_page_1_id", "featured_page_2_id"]
+      (Home.column_names - columns_to_exclude).each do |c|
+        row c.to_sym
+      end
+    end
+    active_admin_comments
+  end
+
   form do |f|
     f.inputs do
       f.input :intro, as: :trix_editor

--- a/app/admin/home.rb
+++ b/app/admin/home.rb
@@ -20,10 +20,10 @@ ActiveAdmin.register Home do
         image_tag(home.featured_image, style: 'width:200px;height:auto;')
       end
       row :featured_page_1 do |home|
-        link_to(home.featured_page_1.title, url_for(home.featured_page_1))
+        link_to(home.featured_page_1.title, url_for(home.featured_page_1), target: '_blank')
       end
       row :featured_page_2 do |home|
-        link_to(home.featured_page_2.title, url_for(home.featured_page_2))
+        link_to(home.featured_page_2.title, url_for(home.featured_page_2), target: '_blank')
       end
       columns_to_exclude = ["id", "intro", "featured_image",
                             "featured_page_1_id", "featured_page_2_id"]

--- a/app/admin/page.rb
+++ b/app/admin/page.rb
@@ -1,11 +1,33 @@
 ActiveAdmin.register Page do
+  controller do
+    defaults :finder => :find_by_slug
+  end
+
   index do
     column :title
     column :content do |post|
       truncate(strip_tags(post.content), length: 300)
     end
     column :show_in_menu
+    column :direct_link do |page|
+      @url = url_for(page)
+      link_to(@url, @url, target: '_blank')
+    end
     actions
+  end
+
+  show do
+    attributes_table do
+      row :title
+      row :content do |page|
+        page.content.html_safe
+      end
+      columns_to_exclude = ["title", "content"]
+      (Page.column_names - columns_to_exclude).each do |c|
+        row c.to_sym
+      end
+    end
+    active_admin_comments
   end
 
   form do |f|

--- a/app/admin/page.rb
+++ b/app/admin/page.rb
@@ -22,6 +22,10 @@ ActiveAdmin.register Page do
       row :content do |page|
         page.content.html_safe
       end
+      row :direct_link do |page|
+        @url = url_for(page)
+        link_to(@url, @url, target: '_blank')
+      end
       columns_to_exclude = ["title", "content"]
       (Page.column_names - columns_to_exclude).each do |c|
         row c.to_sym

--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -17,3 +17,6 @@
 // For example, to change the default status-tag color:
 //
 //   .status_tag { background: #6090DB; }
+.attributes_table .attachment {
+  text-align: center;
+}

--- a/app/models/blog_post.rb
+++ b/app/models/blog_post.rb
@@ -21,4 +21,5 @@ class BlogPost < ApplicationRecord
   include HasSlug
 
   belongs_to :author, class_name: 'Admin'
+  alias_attribute :to_param, :slug
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -20,4 +20,5 @@ class Page < ApplicationRecord
   include HasSlug
 
   belongs_to :parent, class_name: 'Page', optional: true
+  alias_attribute :to_param, :slug
 end


### PR DESCRIPTION
- Override `to_param` so user-friendly links are used everywhere. Override ActiveAdmin's `finder` to match.
- Add direct links to BlogPost and Page indexes, for easy reference.
- Customize Home index page similar to how other indexes are already customized.
- Customize Home, BlogPost, and Page show pages with more useful content - render HTML sometimes, show images, show direct links, etc.