### PR TITLE
Footer links now controlled by MenuItems, too

### DIFF
--- a/app/admin/blog_post.rb
+++ b/app/admin/blog_post.rb
@@ -46,7 +46,7 @@ ActiveAdmin.register BlogPost do
       f.input :title, as: :string
       f.input :content, as: :trix_editor
       f.input :featured_image, as: :s3_url
-      f.input :slug, placeholder: 'Will be automatically generated if blank'
+      f.input :slug, hint: 'Blog posts live at "/blog/:slug". Will be automatically generated if blank'
       f.input :author
       f.input :posted_at
     end

--- a/app/admin/blog_post.rb
+++ b/app/admin/blog_post.rb
@@ -55,3 +55,4 @@ ActiveAdmin.register BlogPost do
 
   permit_params :title, :content, :slug, :author_id, :posted_at, :featured_image
 end
+

--- a/app/admin/blog_post.rb
+++ b/app/admin/blog_post.rb
@@ -55,4 +55,3 @@ ActiveAdmin.register BlogPost do
 
   permit_params :title, :content, :slug, :author_id, :posted_at, :featured_image
 end
-

--- a/app/admin/menu_item.rb
+++ b/app/admin/menu_item.rb
@@ -3,10 +3,25 @@ ActiveAdmin.register MenuItem do
   config.sort_order = 'position_asc' # assumes you are using 'position' for your acts_as_list column
 
   index do
+    panel 'How Menu Items work!' do
+      'Menu items can either belong to the "header" or the "footer", according to their "container" column. This list is ordered (you can reorder it by dragging the items up or down with the little triple-bar), and technically we have the two lists intermingled. But please be polite and keep the "footer" items in order at the bottom, and the "header" items in order at the top. Just to be nice.'
+    end
     handle_column
+    column :position
     column :label
     column :slug
+    column :container
+    actions
   end
 
-  permit_params :label, :slug, :order
+  form do |f|
+    f.inputs do
+      f.input :label, as: :string
+      f.input :slug, as: :string, hint: 'Must begin with \'/\' for relative links, or \'http\' for outbound links'
+      f.input :container, as: :select, collection: ['header', 'footer']
+    end
+    f.actions
+  end
+
+  permit_params :label, :slug, :container, :order
 end

--- a/app/admin/page.rb
+++ b/app/admin/page.rb
@@ -39,9 +39,9 @@ ActiveAdmin.register Page do
     f.inputs do
       f.input :title, as: :string
       f.input :content, as: :trix_editor
-      f.input :slug, placeholder: 'Will be automatically generated if blank'
+      f.input :slug, hint: 'This is the FULL path of the page after our root domain, and it has nothing to do with parent/child pages. E.g. if you want a page to live at "/about/mission", put "/about/mission" here.'
       f.input :parent
-      f.input :subtitle, as: :string, description: "Used when displaying a link to a subpage"
+      f.input :subtitle, as: :string, hint: "Used when displaying a link to a subpage"
     end
     f.actions
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,10 +3,6 @@ class ApplicationController < ActionController::Base
 
   layout 'application'
 
-  before_action do
-    @menu = MenuItem.all
-  end
-
   def nation_builder_client
     unless @nation_builder_client
       unless ENV['NATION_NAME'] && ENV['NATION_API_TOKEN']

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,10 +12,10 @@ module ApplicationHelper
   end
 
   def header_menu_items
-    @header_menu_items ||= MenuItem.where(container: 'header')
+    @header_menu_items ||= MenuItem.header
   end
 
   def footer_menu_items
-    @footer_menu_items ||= MenuItem.where(container: 'footer')
+    @footer_menu_items ||= MenuItem.footer
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,4 +10,12 @@ module ApplicationHelper
   def format_time_short time
     time.strftime("%-l:%M%P")
   end
+
+  def header_menu_items
+    @header_menu_items ||= MenuItem.where(container: 'header')
+  end
+
+  def footer_menu_items
+    @footer_menu_items ||= MenuItem.where(container: 'footer')
+  end
 end

--- a/app/models/menu_item.rb
+++ b/app/models/menu_item.rb
@@ -8,10 +8,22 @@
 #  position   :integer
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  container  :string
 #
 
 class MenuItem < ApplicationRecord
   acts_as_list top_of_list: 0
 
   default_scope { order(position: :asc) }
+
+  validates :label, presence: true
+  validates :slug, presence: true
+  validates :container, presence: true
+  validate :slug_is_relative_or_absolute
+
+  def slug_is_relative_or_absolute
+    return true if slug.to_s.first == '/'
+    return true if slug.to_s[0..3] == 'http'
+    self.errors[:slug] << 'must begin with \'/\' or \'http\''
+  end
 end

--- a/app/models/menu_item.rb
+++ b/app/models/menu_item.rb
@@ -8,11 +8,12 @@
 #  position   :integer
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  container  :string
+#  container  :integer
 #
 
 class MenuItem < ApplicationRecord
   acts_as_list top_of_list: 0
+  enum container: [ :header, :footer ]
 
   default_scope { order(position: :asc) }
 

--- a/app/models/menu_item.rb
+++ b/app/models/menu_item.rb
@@ -17,13 +17,6 @@ class MenuItem < ApplicationRecord
   default_scope { order(position: :asc) }
 
   validates :label, presence: true
-  validates :slug, presence: true
+  validates :slug, presence: true, format: { with: /\A(\/|http).*/i, message: 'must begin with "/" or "http"'}
   validates :container, presence: true
-  validate :slug_is_relative_or_absolute
-
-  def slug_is_relative_or_absolute
-    return true if slug.to_s.first == '/'
-    return true if slug.to_s[0..3] == 'http'
-    self.errors[:slug] << 'must begin with \'/\' or \'http\''
-  end
 end

--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -27,7 +27,7 @@
         <%= link_to(image_tag('dsa-logo-with-text.svg', class: 'header__logo'), root_path) %>
 
         <ul class='header__menu'>
-          <% @menu.each do |item| %>
+          <% header_menu_items.each do |item| %>
             <li class='header__menu_item'><%= link_to item.label, '/' + item.slug %></li>
           <% end %>
         </ul>
@@ -46,20 +46,9 @@
         <div>
           <h3>Get Involved</h3>
           <ul class='footer__nav_list'>
-            <li><%= link_to 'Home', root_path %></li>
-            <li><%= link_to 'About', '/about' %></li>
-            <li><%= link_to 'Events', '/events' %></li>
-            <li><%= link_to 'News', '/blog' %></li>
-            <li><%= link_to 'Resources', '/resoures' %></li>
-            <li><%= link_to 'Campaigns', '/campaigns' %></li>
-          </ul>
-        </div>
-        <div>
-          <h3>Donate</h3>
-          <ul class='footer__nav_list'>
-            <li><%= link_to 'Donate', '/donate' %></li>
-            <li><%= link_to 'Store', '/store' %></li>
-            <li><%= link_to 'Join', '/join' %></li>
+            <% footer_menu_items.each do |item| %>
+              <li><%= link_to item.label, item.slug %></li>
+            <% end %>
           </ul>
         </div>
         <div>

--- a/db/migrate/20180325173740_add_container_to_menu_items.rb
+++ b/db/migrate/20180325173740_add_container_to_menu_items.rb
@@ -1,0 +1,8 @@
+class AddContainerToMenuItems < ActiveRecord::Migration[5.1]
+  def change
+    add_column :menu_items, :container, :string
+
+    MenuItem.reset_column_information
+    MenuItem.update_all container: 'header'
+  end
+end

--- a/db/migrate/20180326193533_change_menu_item_container_to_int.rb
+++ b/db/migrate/20180326193533_change_menu_item_container_to_int.rb
@@ -1,0 +1,7 @@
+class ChangeMenuItemContainerToInt < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :menu_items, :container
+    add_column :menu_items, :container, :integer
+    MenuItem.update_all container: :header
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180325173740) do
+ActiveRecord::Schema.define(version: 20180326193533) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -72,7 +72,7 @@ ActiveRecord::Schema.define(version: 20180325173740) do
     t.integer "position"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "container"
+    t.integer "container"
   end
 
   create_table "pages", force: :cascade do |t|
@@ -85,6 +85,14 @@ ActiveRecord::Schema.define(version: 20180325173740) do
     t.datetime "updated_at", null: false
     t.text "subtitle"
     t.index ["slug"], name: "index_pages_on_slug", unique: true
+  end
+
+  create_table "redirects", force: :cascade do |t|
+    t.string "from_path"
+    t.string "to_url"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "clicks", default: 0
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180106080018) do
+ActiveRecord::Schema.define(version: 20180325173740) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -72,6 +72,7 @@ ActiveRecord::Schema.define(version: 20180106080018) do
     t.integer "position"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "container"
   end
 
   create_table "pages", force: :cascade do |t|

--- a/test/fixtures/menu_items.yml
+++ b/test/fixtures/menu_items.yml
@@ -8,7 +8,7 @@
 #  position   :integer
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  container  :string
+#  container  :integer
 #
 
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html

--- a/test/fixtures/menu_items.yml
+++ b/test/fixtures/menu_items.yml
@@ -8,6 +8,7 @@
 #  position   :integer
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  container  :string
 #
 
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html

--- a/test/models/menu_item_test.rb
+++ b/test/models/menu_item_test.rb
@@ -8,6 +8,7 @@
 #  position   :integer
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  container  :string
 #
 
 require 'test_helper'

--- a/test/models/menu_item_test.rb
+++ b/test/models/menu_item_test.rb
@@ -8,7 +8,7 @@
 #  position   :integer
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  container  :string
+#  container  :integer
 #
 
 require 'test_helper'


### PR DESCRIPTION
`MenuItems` can now belong to the "header" or "footer", according to their "container" column, which controls the links. 

Also, `MenuItem` slugs must now begin with either `/` or `http`, which allows us to add outbound links, as well (like the Donate link, once it's ready).

Closes #73 
Closes #59 