### PR TITLE
Redirects model done

### DIFF
--- a/app/admin/redirect.rb
+++ b/app/admin/redirect.rb
@@ -1,0 +1,28 @@
+ActiveAdmin.register Redirect do
+  index do
+    column :from_path
+    column :to_url
+    column :clicks
+    actions
+  end
+
+  show do
+    attributes_table do
+      row :from_path
+      row :to_url
+      row :clicks
+    end
+    active_admin_comments
+  end
+
+  form do |f|
+    f.inputs do
+      f.input :from_path, as: :string, hint: 'Must begin with "/". Once created, cannot be changed (just delete/recreate new ones)', input_html: { disabled: f.object.persisted? }
+      f.input :to_url, as: :string, hint: 'Must begin with "/" for relative links, or "http" for outbound links'
+    end
+    f.actions
+  end
+
+  permit_params :from_path, :to_url
+end
+

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,5 @@
 class PagesController < ApplicationController
+  before_action :check_for_redirects, only: :show
   layout 'home', only: 'home'
 
   def home
@@ -13,4 +14,12 @@ class PagesController < ApplicationController
     @page = Page.find_by_slug!(params[:slug])
   end
 
+private
+
+  def check_for_redirects
+    if params[:slug] and r = Redirect.find_by_from_path("/#{params[:slug]}")
+      r.increment! :clicks
+      redirect_to r.to_url
+    end
+  end
 end

--- a/app/models/redirect.rb
+++ b/app/models/redirect.rb
@@ -1,0 +1,16 @@
+# == Schema Information
+#
+# Table name: redirects
+#
+#  id         :integer          not null, primary key
+#  from_path  :string
+#  to_url     :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  clicks     :integer          default(0)
+#
+
+class Redirect < ApplicationRecord
+  validates :from_path, presence: true, format: { with: /\A\/.*/i, message: 'must begin with "/"'}
+  validates :to_url, presence: true, format: { with: /\A(\/|http).*/i, message: 'must begin with "/" or "http"'}
+end

--- a/db/migrate/20180325201817_create_redirects.rb
+++ b/db/migrate/20180325201817_create_redirects.rb
@@ -1,0 +1,10 @@
+class CreateRedirects < ActiveRecord::Migration[5.1]
+  def change
+    create_table :redirects do |t|
+      t.string :from_path
+      t.string :to_url
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180325203325_add_clicks_to_redirects.rb
+++ b/db/migrate/20180325203325_add_clicks_to_redirects.rb
@@ -1,0 +1,5 @@
+class AddClicksToRedirects < ActiveRecord::Migration[5.1]
+  def change
+    add_column :redirects, :clicks, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180106080018) do
+ActiveRecord::Schema.define(version: 20180325203325) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -84,6 +84,14 @@ ActiveRecord::Schema.define(version: 20180106080018) do
     t.datetime "updated_at", null: false
     t.text "subtitle"
     t.index ["slug"], name: "index_pages_on_slug", unique: true
+  end
+
+  create_table "redirects", force: :cascade do |t|
+    t.string "from_path"
+    t.string "to_url"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "clicks", default: 0
   end
 
 end

--- a/test/fixtures/redirects.yml
+++ b/test/fixtures/redirects.yml
@@ -1,0 +1,21 @@
+# == Schema Information
+#
+# Table name: redirects
+#
+#  id         :integer          not null, primary key
+#  from_path  :string
+#  to_url     :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  clicks     :integer          default(0)
+#
+
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  from_path: MyString
+  to_url: MyString
+
+two:
+  from_path: MyString
+  to_url: MyString

--- a/test/models/redirect_test.rb
+++ b/test/models/redirect_test.rb
@@ -1,0 +1,19 @@
+# == Schema Information
+#
+# Table name: redirects
+#
+#  id         :integer          not null, primary key
+#  from_path  :string
+#  to_url     :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  clicks     :integer          default(0)
+#
+
+require 'test_helper'
+
+class RedirectTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Pretty simple redirect model set up, you just add a `from_path` and a `to_url` (which can be relative or absolute), and it checks for the redirects before the catch-all route for pages (so you can't override admin or blog routes using this scheme, but you can override page slugs using it).

Closes #69