### PR TITLE
Breadcrumbs

### DIFF
--- a/app/admin/page.rb
+++ b/app/admin/page.rb
@@ -8,7 +8,6 @@ ActiveAdmin.register Page do
     column :content do |post|
       truncate(strip_tags(post.content), length: 300)
     end
-    column :show_in_menu
     column :direct_link do |page|
       @url = url_for(page)
       link_to(@url, @url, target: '_blank')
@@ -39,7 +38,7 @@ ActiveAdmin.register Page do
     f.inputs do
       f.input :title, as: :string
       f.input :content, as: :trix_editor
-      f.input :slug, hint: 'This is the FULL path of the page after our root domain, and it has nothing to do with parent/child pages. E.g. if you want a page to live at "/about/mission", put "/about/mission" here.'
+      f.input :slug, hint: 'This is the FULL path of the page after our root domain, and it has nothing to do with parent/child pages. E.g. if you want a page to live at "eastbaydsa.org/about/mission", put "about/mission" here.'
       f.input :parent
       f.input :subtitle, as: :string, hint: "Used when displaying a link to a subpage"
     end

--- a/app/models/concerns/has_slug.rb
+++ b/app/models/concerns/has_slug.rb
@@ -3,6 +3,7 @@ module HasSlug
 
   included do
     before_validation :set_slug_if_empty
+    before_validation :remove_leading_slash_from_slug
 
     validates_presence_of :title, :slug
     validates_uniqueness_of :slug
@@ -11,6 +12,12 @@ module HasSlug
   def set_slug_if_empty
     if self.slug.empty?
       self.slug = self.title.parameterize
+    end
+  end
+
+  def remove_leading_slash_from_slug
+    if self.slug.present? and self.slug.first == '/'
+      self.slug = self.slug[1..-1]
     end
   end
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -24,4 +24,14 @@ class Page < ApplicationRecord
   belongs_to :parent, class_name: 'Page', optional: true
 
   alias_attribute :to_param, :slug
+
+  def all_parents
+    parents = []
+    page = self
+    while page.parent
+      parents << page.parent
+      page = page.parent
+    end
+    parents
+  end
 end

--- a/app/views/blog_posts/show.html.erb
+++ b/app/views/blog_posts/show.html.erb
@@ -1,3 +1,7 @@
+<div class="breadcrumbs">
+  <%= link_to "Blog", blog_posts_path %> &raquo; <%= @post.title %>
+</div>
+
 <div class='blog-post__header'>
   <h1><%= @post.title %></h1>
 

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, @event.name %>
 
 <div class="breadcrumbs">
-  <%= link_to "Events", events_path %> » <%= @event.name %>
+  <%= link_to "Events", events_path %> &raquo; <%= @event.name %>
 </div>
 
 <div class="event">

--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -28,7 +28,7 @@
 
         <ul class='header__menu'>
           <% header_menu_items.each do |item| %>
-            <li class='header__menu_item'><%= link_to item.label, '/' + item.slug %></li>
+            <li class='header__menu_item'><%= link_to item.label, item.slug %></li>
           <% end %>
         </ul>
 

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -16,7 +16,6 @@
   </article>
 
   <div class="subpages">
-    <% flip = true %>
     <% @page.subpages.each_with_index do |subpage, index| %>
       <%= link_to page_path(subpage), class: "subpages--subpage" do %>
         <span><%= subpage.subtitle %>&nbsp;</span>

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -1,6 +1,15 @@
 <%= content_for :title, @page.title %>
 
 <div class="content__centered">
+  <% if @page.parent %>
+    <div class='breadcrumbs'>
+      <% for parent in @page.all_parents.reverse %>
+        <%= link_to parent.title, parent.slug %>
+        &raquo;
+      <% end %>
+      <%= @page.title %>
+    </div>
+  <% end %>
   <article>
     <h1><%= @page.title %></h1>
 

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -4,8 +4,7 @@
   <% if @page.parent %>
     <div class='breadcrumbs'>
       <% for parent in @page.all_parents.reverse %>
-        <%= link_to parent.title, parent.slug %>
-        &raquo;
+        <%= link_to parent.title, parent.slug %> &raquo;
       <% end %>
       <%= @page.title %>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
 
   resources :events, only: [:index, :show]
 
-  get 'blog', to: 'blog_posts#index'
+  get 'blog', to: 'blog_posts#index', as: 'blog_posts'
   get 'blog/*slug', to: 'blog_posts#show', as: 'blog_post'
   get 'newsletter', to: 'newsletter#index'
   post 'newsletter', to: 'newsletter#create', as: 'submit_newsletter'


### PR DESCRIPTION
Closes #93 

Added breadcrumbs to `Blog post`s and `Page`s. Since Resources, Campaigns, etc should all be `Page` objects, they will all show breadcrumbs. Just make sure to set the `parent` on any `Page`, otherwise no breadcrumbs will show up.

Screenshots:

<img width="790" alt="screen shot 2018-04-05 at 4 58 41 pm" src="https://user-images.githubusercontent.com/1200038/38397702-05acacc6-38f4-11e8-8d31-ee26f79b001f.png">

<img width="440" alt="screen shot 2018-04-05 at 5 02 47 pm" src="https://user-images.githubusercontent.com/1200038/38397706-0c7b3d1a-38f4-11e8-9469-b24de45c65ed.png">
