### PR TITLE
Add viewport meta tags for phonez

### DIFF
--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -5,6 +5,9 @@
     <title><%= title.blank? ? '' : "#{title} | " %>East Bay DSA</title>
     <%= csrf_meta_tags %>
 
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
     <% if ENV['GOOGLE_ANALYTICS_ID'] %>
       <!-- Global Site Tag (gtag.js) - Google Analytics -->
       <script async src="https://www.googletagmanager.com/gtag/js?id=<%= ENV['GOOGLE_ANALYTICS_ID'] %>"></script>


### PR DESCRIPTION
Closes #127 

Without these meta tags the phone renders a full page version, just very small. 