### PR TITLE
Event calendar just lists events on mobile

### DIFF
--- a/app/assets/stylesheets/application/_content.scss
+++ b/app/assets/stylesheets/application/_content.scss
@@ -4,12 +4,20 @@
   padding: $extra_spacing 0 50px;
 }
 
-.hidden-mobile { display: block; }
-.visible-mobile { display: none; }
+.hidden-mobile {
+  display: block;
+}
+.visible-mobile {
+  display: none;
+}
 
-@media (max-width: $mobile_break_point) {
-  .hidden-mobile { display: none; }
-  .visible-mobile { display: block; }
+@media (max-width: $tablet_break_point) {
+  .hidden-mobile {
+    display: none;
+  }
+  .visible-mobile {
+    display: block;
+  }
 }
 
 /**
@@ -26,7 +34,8 @@ article {
     padding-left: $default_spacing;
   }
 
-  ul, ol {
+  ul,
+  ol {
     margin-left: $default_spacing/2;
     list-style-position: inside;
   }

--- a/app/assets/stylesheets/application/_content.scss
+++ b/app/assets/stylesheets/application/_content.scss
@@ -4,6 +4,14 @@
   padding: $extra_spacing 0 50px;
 }
 
+.hidden-mobile { display: block; }
+.visible-mobile { display: none; }
+
+@media (max-width: $mobile_break_point) {
+  .hidden-mobile { display: none; }
+  .visible-mobile { display: block; }
+}
+
 /**
  * Trix previews attachments as centered, help the render match that.
  */

--- a/app/assets/stylesheets/application/_events.scss
+++ b/app/assets/stylesheets/application/_events.scss
@@ -18,6 +18,12 @@
 }
 
 .simple-calendar {
+  padding-top: $default_spacing * 2;
+  @media (min-width: $max-width + 100px) {
+    width: $largest_width;
+    margin: 0 auto;
+  }
+
   .day {
     min-height: 80px;
     height: auto;
@@ -46,6 +52,8 @@
     display: flex;
     border-left: 1px solid $border_color;
     border-bottom: 1px solid $border_color;
+    margin: 0;
+    padding: 0;
   }
 
   .day {
@@ -101,7 +109,7 @@
     padding: 3px 0 3px 5px;
 
     &:hover {
-       border-color: $dsa_red;
+      border-color: $dsa_red;
     }
   }
 

--- a/app/assets/stylesheets/application/_events.scss
+++ b/app/assets/stylesheets/application/_events.scss
@@ -18,12 +18,6 @@
 }
 
 .simple-calendar {
-  padding-top: $default_spacing * 2;
-  @media (min-width: $max-width + 100px) {
-    width: $largest_width;
-    margin: 0 auto;
-  }
-
   .day {
     min-height: 80px;
     height: auto;
@@ -52,8 +46,6 @@
     display: flex;
     border-left: 1px solid $border_color;
     border-bottom: 1px solid $border_color;
-    margin: 0;
-    padding: 0;
   }
 
   .day {
@@ -109,7 +101,7 @@
     padding: 3px 0 3px 5px;
 
     &:hover {
-      border-color: $dsa_red;
+       border-color: $dsa_red;
     }
   }
 

--- a/app/assets/stylesheets/variables_and_mixins.scss
+++ b/app/assets/stylesheets/variables_and_mixins.scss
@@ -8,6 +8,7 @@ $light_text_color: #888;
 // Layout
 $largest_width: calc(100% - 100px);
 $max_width: 750px;
+$tablet_break_point: 768px;
 $mobile_break_point: 500px;
 $default_spacing: 20px;
 $extra_spacing: 30px;

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -11,6 +11,12 @@ class EventsController < ApplicationController
     end_date = @start_date.end_of_month
 
     @events = Event.query(@start_date.to_s, end_date.to_s)
+
+    if @start_date == Date.today.beginning_of_month
+      # viewing current month, setup an array of only upcoming events
+      @upcoming_events = @events.select{|e| e.start_time.future? }
+    end
+
     render layout: 'full_width'
   end
 

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,28 +1,62 @@
 <div class='container'>
   <h1>East Bay DSA events</h1>
 
-  <p>Want to learn more about East Bay DSA? Attend one of our many events in
+  <p>
+    Want to learn more about East Bay DSA? Attend one of our many events in
     the area to find out how you can get involved in improving the lives
-    of working people.</p>
-</div>
+    of working people.
+  </p>
 
-<%= month_calendar events: @events do |date, events| %>
-  <span class='simple-calendar--date-wrapper'>
-    <span class='simple-calendar--date'>
-      <%= date.day %>
-    </span>
-  </span>
 
-  <div class='simple-calendar--events'>
-    <% events.each do |event| %>
-      <%= link_to event_path(event, slug: event.slug), class: 'simple-calendar--events--event' do %>
-        <span class='simple-calendar--events--event-title'><%= event.name %><span>
-        <br />
-        <span class='simple-calendar--events--event-time'><%= format_time_range_short event.start_time, event.end_time %></span>
+  <div class='visible-mobile'>
+    <h2 class='calendar-heading'>
+      <%= link_to events_path(start_date: @start_date-1.month) do %>
+        <i class='fa fa-caret-left'></i>
       <% end %>
+      <%= @start_date.strftime('%B %Y') %>
+      <%= link_to events_path(start_date: @start_date+1.month) do %>
+        <i class='fa fa-caret-right'></i>
+      <% end %>
+    </h2>
+
+    <% @events.each do |event| %>
+      <article>
+        <p>
+          <%= link_to event.name, event_path(event, slug: event.slug) %><br>
+          <%= event.start_time.strftime('%A, %B %e, %Y at %l:%M %p') %>
+        </p>
+      </article>
+    <% end %>
+    <% if @events.blank? %>
+      <em>No upcoming events!</em>
     <% end %>
   </div>
-<% end %>
+
+</div>
+
+
+
+
+<div class='hidden-mobile'>
+  <br>
+  <%= month_calendar events: @events do |date, events| %>
+    <span class='simple-calendar--date-wrapper'>
+      <span class='simple-calendar--date'>
+        <%= date.day %>
+      </span>
+    </span>
+
+    <div class='simple-calendar--events'>
+      <% events.each do |event| %>
+        <%= link_to event_path(event, slug: event.slug), class: 'simple-calendar--events--event' do %>
+          <span class='simple-calendar--events--event-title'><%= event.name %><span>
+          <br />
+          <span class='simple-calendar--events--event-time'><%= format_time_range_short event.start_time, event.end_time %></span>
+        <% end %>
+      <% end %>
+    </div>
+  <% end %>
+</div>
 
 <% content_for :schema do %>
   <script type="application/ld+json">

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -19,7 +19,8 @@
       <% end %>
     </h2>
 
-    <% @events.each do |event| %>
+    <!-- Mobile should only display upcoming_events if it's set, otherwise all events -->
+    <% (@upcoming_events || @events).each do |event| %>
       <article>
         <p>
           <%= link_to event.name, event_path(event, slug: event.slug) %><br>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -28,8 +28,13 @@
         </p>
       </article>
     <% end %>
-    <% if @events.blank? %>
-      <em>No upcoming events!</em>
+    <% if (@upcoming_events || @events).blank? %>
+      <em>
+        No
+        <%= @start_date.beginning_of_month >= Date.today.beginning_of_month ? 'upcoming' : '' %>
+        events for
+        <%= @start_date.strftime('%B') %>
+      </em>
     <% end %>
   </div>
 


### PR DESCRIPTION
Instead of a super cramped calendar, mobile phones will just see events listed vertically.]

Closes #125 

This:
![image](https://user-images.githubusercontent.com/1200038/40502746-c433a20e-5f40-11e8-8074-fd5d3da7417d.png)

Instead of this: 
![image](https://user-images.githubusercontent.com/1200038/40502761-cfd2e110-5f40-11e8-9e39-ec37e1bf1abe.png)
