### PR TITLE
Add tag filter to calendar

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,10 +19,6 @@ gem 'uglifier', '>= 1.3.0'
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'therubyracer', platforms: :ruby
 
-# Use CoffeeScript for .coffee assets and views
-gem 'coffee-rails', '~> 4.2'
-# Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
-gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'
 # Use Redis adapter to run Action Cable in production

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -261,9 +261,6 @@ GEM
     tilt (2.0.8)
     trix (0.11.0)
       rails (> 4.1, < 5.2)
-    turbolinks (5.0.1)
-      turbolinks-source (~> 5)
-    turbolinks-source (5.0.3)
     tzinfo (1.2.3)
       thread_safe (~> 0.1)
     uber (0.0.15)
@@ -296,7 +293,6 @@ DEPENDENCIES
   aws-sdk-s3 (~> 1)
   byebug
   capybara (~> 2.13)
-  coffee-rails (~> 4.2)
   devise
   dotenv-rails
   font-awesome-rails (~> 4.7, >= 4.7.0.2)
@@ -314,7 +310,6 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   trix
-  turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,5 +12,4 @@
 //
 //= require rails-ujs
 //= require jquery
-//= require turbolinks
 //= require_tree ./application

--- a/app/assets/javascripts/application/calendar.js
+++ b/app/assets/javascripts/application/calendar.js
@@ -1,0 +1,44 @@
+$(document).ready(function() {
+  var selectedFilter = $('#calendar-filter select').value;
+
+  currentTag = getUrlVars()['tags'];
+  $('#calendar-filter option[value="' + currentTag + '"]').prop(
+    'selected',
+    'selected'
+  );
+
+  $('#calendar-filter select').on('change', function(event) {
+    var newSelected = event.target.value;
+    if (selectedFilter != newSelected) {
+      var params = {
+        tags: newSelected
+      };
+
+      var startDate = getUrlVars()['start_date'];
+      if (startDate) {
+        params['start_date'] = startDate;
+      }
+
+      window.location.href =
+        window.location.origin +
+        window.location.pathname +
+        '?' +
+        $.param(params);
+    }
+  });
+});
+
+// Read a page's GET URL variables and return them as an associative array.
+function getUrlVars() {
+  var vars = [],
+    hash;
+  var hashes = window.location.href
+    .slice(window.location.href.indexOf('?') + 1)
+    .split('&');
+  for (var i = 0; i < hashes.length; i++) {
+    hash = hashes[i].split('=');
+    vars.push(hash[0]);
+    vars[hash[0]] = hash[1];
+  }
+  return vars;
+}

--- a/app/assets/stylesheets/application/_events.scss
+++ b/app/assets/stylesheets/application/_events.scss
@@ -1,12 +1,16 @@
 @import 'variables_and_mixins';
 
-// Style simple-calendar markup
+#calendar-filter {
+  select {
+    min-width: 200px;
+  }
+}
 
 .calendar-heading {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: $default_spacing/2;
+  padding-top: $default_spacing;
 
   a {
     font-size: $h2_font_size;
@@ -17,8 +21,9 @@
   font-size: $h2_font_size;
 }
 
+// Style simple-calendar markup
 .simple-calendar {
-  padding-top: $default_spacing * 2;
+  padding-top: $default_spacing;
   @media (min-width: $max-width + 100px) {
     width: $largest_width;
     margin: 0 auto;

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -9,9 +9,13 @@ class EventsController < ApplicationController
     end
 
     end_date = @start_date.end_of_month
+    tags = params[:tags] if params[:tags]
 
-    @events = Event.query((@start_date - 7.days).to_s, (end_date + 7.days).to_s)
-
+    @events = Event.query(
+      start_date: (@start_date - 7.days).to_s,
+      end_date: (end_date + 7.days).to_s,
+      tags: tags
+    )
 
     @upcoming_events = @events.select{|e|
       e.start_time > @start_date.to_time.beginning_of_day &&

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -5,7 +5,11 @@ class PagesController < ApplicationController
     @page = Page.where(slug: 'home').first
     @page ||= Page.first
 
-    @events = Event.query(Date.today, nil, 3)
+    @events = Event.query(
+      start_date: Date.today,
+      end_date: nil,
+      limit: 3
+    )
     render :show
   end
 
@@ -13,10 +17,10 @@ class PagesController < ApplicationController
     @page = Page.find_by_slug!(params[:slug])
   end
 
-private
+  private
 
   def check_for_redirects
-    if params[:slug] and r = Redirect.find_by_from_path("/#{params[:slug]}")
+    if params[:slug] && r = Redirect.find_by_from_path("/#{params[:slug]}")
       r.increment! :clicks
       redirect_to r.to_url
     end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -34,16 +34,17 @@
     @nation_builder_client
   end
 
-  def self.query(start_date, end_date = nil, limit = 1000)
+  def self.query(start_date: Date.today, end_date: nil, limit: 1000, tags: nil)
     opts = {
       site_slug: ENV['NATION_SITE_SLUG'],
       starting: start_date,
       limit: limit
     }
+    opts[:tags] = tags if tags
     opts[:until] = end_date if end_date
 
     @events = client.call(:events, :index, opts)["results"]
-      .select{ |e| e["published_at"] != nil }
+      .select{ |e| ['published', 'expired'].include?(e['status']) }
       .map{ |e| Event.new(e) }
       # .maxListLength...
   end

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -9,17 +9,29 @@
     </p>
   </div>
 
-  <div class='visible-mobile'>
-    <h2 class='calendar-heading'>
-      <%= link_to events_path(start_date: @start_date-1.month) do %>
-        <i class='fa fa-caret-left'></i>
-      <% end %>
-      <%= @start_date.strftime('%B %Y') %>
-      <%= link_to events_path(start_date: @start_date+1.month) do %>
-        <i class='fa fa-caret-right'></i>
-      <% end %>
-    </h2>
+  <form id='calendar-filter'>
+    <p>
+      <strong>Filter calendar:</strong>
+      <%= select_tag 'tags', options_for_select([
+        ['All events', ''],
+        ['Meetings', 'meeting'],
+        ['Canvasses', 'canvass'],
+        ['Phone Bank', 'phonebank']
+      ]) %>
+    </p>
+  </form>
 
+  <h2 class='calendar-heading'>
+    <%= link_to events_path(start_date: @start_date-1.month, tags: params[:tags]) do %>
+      <i class='fa fa-caret-left'></i>
+    <% end %>
+    <%= @start_date.strftime('%B %Y') %>
+    <%= link_to events_path(start_date: @start_date+1.month, tags: params[:tags]) do %>
+      <i class='fa fa-caret-right'></i>
+    <% end %>
+  </h2>
+
+  <div class='visible-mobile'>
     <!-- Mobile should only display upcoming_events if it's set, otherwise all events -->
     <% @upcoming_events.each do |event| %>
       <article>

--- a/app/views/simple_calendar/_month_calendar.html.erb
+++ b/app/views/simple_calendar/_month_calendar.html.erb
@@ -1,14 +1,4 @@
 <div class="simple-calendar">
-  <div class="calendar-heading">
-    <%= link_to events_path(start_date: @start_date - 1.month) do %>
-      <i class="fa fa-caret-left"></i>
-    <% end %>
-    <span class="calendar-title"><%= t('date.month_names')[start_date.month] %> <%= start_date.year %></span>
-    <%= link_to events_path(start_date: @start_date + 1.month) do %>
-      <i class="fa fa-caret-right"></i>
-    <% end %>
-  </div>
-
   <div class="table table-striped">
     <div class="table-head">
       <ul class="days">


### PR DESCRIPTION
The calendar can be filtered on a pre-determined list of tags; the initial
list here is "Meeting", "Phone Bank" and "Canvass", but this could easily
be updated to include individual committees or campaigns as we see fit.