### PR TITLE
Fix posted_at value in activeadmin

### DIFF
--- a/app/admin/blog_post.rb
+++ b/app/admin/blog_post.rb
@@ -54,7 +54,7 @@ ActiveAdmin.register BlogPost do
   end
 
   form do |f|
-    f.object.posted_at = DateTime.now
+    f.object.posted_at ||= DateTime.now
     f.inputs do
       f.input :title, as: :string
       f.input :content, as: :quill_editor


### PR DESCRIPTION
We set a default value of "right now", but overwrite values when
editing the form.

Fixes #135