### PR TITLE
Layout support for slightly wider navigation

### DIFF
--- a/app/assets/stylesheets/application/_header.scss
+++ b/app/assets/stylesheets/application/_header.scss
@@ -13,9 +13,14 @@
   }
 
   .header__logo {
-    margin-right: 10px;
+    margin-right: 20px;
     height: auto;
     width: 274px;
+    margin-bottom: -5px;
+
+    @media (max-width: $tablet_break_point) {
+      width: 200px;
+    }
   }
 
   ul.header__menu {
@@ -26,7 +31,11 @@
     text-align: right;
     li {
       display: inline-block;
-      margin-left: 30px;
+      margin-left: 15px;
+
+      &:first-child {
+        margin-left: 0;
+      }
     }
   }
   .hamburger { display: none; }
@@ -39,15 +48,11 @@
       display: block;
     }
 
-    .header__logo { width: 200px }
-
     ul.header__menu {
-      //flex-direction: column;
-      //align-items: flex-start;
       margin: 0;
       width: auto;
       text-align: left;
-      li { 
+      li {
         display: block;
         margin: 3px 0;
       }
@@ -59,7 +64,7 @@
       &.show { max-height: 300px; }
     }
 
-    .hamburger { 
+    .hamburger {
       display: inline;
       float: right;
       font-size: 25px;

--- a/app/assets/stylesheets/variables_and_mixins.scss
+++ b/app/assets/stylesheets/variables_and_mixins.scss
@@ -7,7 +7,7 @@ $light_text_color: #888;
 
 // Layout
 $largest_width: calc(100% - 100px);
-$max_width: 750px;
+$max_width: 780px;
 $tablet_break_point: 768px;
 $mobile_break_point: 500px;
 $default_spacing: 20px;


### PR DESCRIPTION
While we figure out information architecture and longer term navigation, we had a feature request from the SC to support the previous site’s navigation for now. 

This change:

* Shrinks the logo earlier at tablet size instead of mobile
* Decreases space between menu items
* Slightly increases max-width for site