### PR TITLE
Update vulnerable `sprockets` dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -251,7 +251,7 @@ GEM
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)


### PR DESCRIPTION
Resolves GitHub security warning