### PR TITLE
Fix Google Analytics tag

### DIFF
--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -18,7 +18,7 @@
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
 
-        gtag('config', <%= ENV['GOOGLE_ANALYTICS_ID'] %>);
+        gtag('config', '<%= ENV['GOOGLE_ANALYTICS_ID'] %>');
       </script>
     <% end %>
 


### PR DESCRIPTION
The analytics ID wasn't quoted originally, parsing the ID
as a variable instead of a string.