### PR TITLE
events: handle error in people/push with fallback

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -48,7 +48,13 @@ class EventsController < ApplicationController
     @event = Event.find(params[:id])
 
     begin
-      person = nation_builder_client.call(:people, :push, person: person_params.to_h )
+      person = nil
+      begin
+        person = nation_builder_client.call(:people, :push, person: person_params.to_h )
+      rescue
+        person = nation_builder_client.call(:people, :match, email: person_params.to_h[:email])
+      end
+
       person_id = person['person']['id']
 
       nation_builder_client.call(:events, :rsvp_create, {


### PR DESCRIPTION
Occassionally, people/push in NB returns an error as
a result of an unresolved bug in NB's API:
https://nationbuilder.com/lauren_rowse/erroneous_import_error_billing_address_phone_number_can_t_be_blank_when_updating_existing_profiles

This catches the error and attempts to search for the
relevant record instead.