### PR TITLE
events: don't pass venue name to Google Maps

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -56,7 +56,7 @@ class Event
 
   def full_address
     fields = [ 'address1', 'address2', 'address3', 'city', 'state', 'zip' ]
-    fields.map{|field| address[field] }.tap{|a| a.unshift(venue) }.select(&:present?).join(', ')
+    fields.map{|field| address[field] }.select(&:present?).join(', ')
   end
 
   def self.client

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -32,6 +32,7 @@
     <%= format_time_range_short @event.start_time, @event.end_time %>
     <br>
     <strong>Where:</strong>
+    <%= @event.venue %>
     <%= @event.full_address %>
     <br>
     <%= link_to 'Add to Google calendar', @event.gcal_url, target: '_blank' %> /
@@ -40,7 +41,7 @@
   </p>
 </div>
 
-    
+
   </p>
 
   <% if @event.accept_rsvps %>


### PR DESCRIPTION
`full_address` excludes venue name, allowing for formats
such as "RSVP for location", or strange edge cases
where the venue name generated a completely incorrect map.

Fixes #167 