### PR TITLE
Redirect using 301 instead of 302.

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -18,7 +18,7 @@ class PagesController < ApplicationController
   def check_for_redirects
     if params[:slug] && r = Redirect.find_by_from_path("/#{params[:slug]}")
       r.increment! :clicks
-      redirect_to r.to_url
+      redirect_to r.to_url, status: :moved_permanently
     end
   end
 end

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -28,4 +28,11 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
     get "#{@pages_uri}/#{pages(:test_page).slug}"
     assert_response :success
   end
+
+  test "redirect" do
+    Redirect.create!(from_path: "/foo", to_url: "/bar")
+    get "/foo"
+    assert_response 301
+    assert_redirected_to "/bar"
+  end
 end


### PR DESCRIPTION
For known redirects from the old site to the new site, these redirects should be considered permanent.

Fixes #162