### PR TITLE
Page forms: optionally collect mobile number

### DIFF
--- a/app/admin/page.rb
+++ b/app/admin/page.rb
@@ -56,11 +56,13 @@ ActiveAdmin.register Page do
     end
     f.inputs 'Sign Up' do
       f.input :show_form, label: 'Display a sign-up form directly after the Content of this page.', hint: 'Make sure to put some text at the end of the "Content" section above, like "Sign up for our newsletter" in bold, to explain what this form signs you up for!'
+      f.input :form_collect_phone, label: 'Collect phone number', hint: 'Useful for text/phone campaigns - requires both email and phone at signup.'
       f.input :form_tags, hint: 'Comma-separated list of NationBuilder tags to add when someone signs up (e.g. "eb_supporter" to sign them up for our newsletter). At least 1 is required.'
     end
     f.actions
   end
 
-  permit_params :title, :subtitle, :content, :slug, :parent_id, :listed, :show_form, :form_tags,
+  permit_params :title, :subtitle, :content, :slug, :parent_id, :listed,
+    :show_form, :form_collect_phone, :form_tags,
     :background_image_url, :meta_title, :meta_desc
 end

--- a/app/assets/stylesheets/application/_forms.scss
+++ b/app/assets/stylesheets/application/_forms.scss
@@ -20,7 +20,9 @@
   align-items: center;
   margin-right: -$compact_spacing;
 
-  input[type=text], input[type=email] {
+  input[type=text],
+  input[type=email],
+  input[type=tel] {
     flex: 1;
     width: 100%;
     margin-bottom: $compact_spacing;
@@ -29,7 +31,7 @@
 
   input[type=submit] {
     margin-bottom: $compact_spacing;
-    margin-right: $compact_spacing;    
+    margin-right: $compact_spacing;
   }
 }
 

--- a/app/controllers/signups_controller.rb
+++ b/app/controllers/signups_controller.rb
@@ -4,22 +4,20 @@ class SignupsController < ApplicationController
   before_action :require_email
 
   def create
-    person_params = { email: email_param }
-    if (params[:phone])
-      person_params[:mobile] = phone_param
-    end
-    person = $nation_builder_client.call(:people, :push, person: person_params)
+    person = $nation_builder_client.call(:people, :push, person: person_params.to_h)
     person_id = person['person']['id']
     $nation_builder_client.call(:people, :tag_person, { id: person_id, tagging: { tag: tags_param }} )
     redirect_back flash: { success: 'Thank you for signing up.' }, fallback_location: root_path
   rescue NationBuilder::ClientError => e
-    redirect_back flash: { error: JSON.parse(e.message)['validation_errors'][0].capitalize }, fallback_location: root_path
+    error = JSON.parse(e.message)['validation_errors'][0].capitalize rescue nil
+    error ||= JSON.parse(e.message)['message']
+    redirect_back flash: { error: error }, fallback_location: root_path
   end
 
 protected
 
   def require_email
-    unless email_param.present?
+    unless person_params[:email].present?
       redirect_back flash: { error: 'Please enter an email address' }, fallback_location: root_path
     end
   end
@@ -29,11 +27,10 @@ protected
     params[:tags].to_s.split(',').map(&:strip).select(&:present?)
   end
 
-  def email_param
-    params[:email].to_s.downcase.strip
-  end
-
-  def phone_param
-    params[:phone].gsub(/[^0-9]/, '')
+  def person_params
+    person = params.fetch(:person, {}).permit :email, :mobile
+    person[:email] = person[:email].downcase.strip if person[:email].present?
+    person[:mobile] = person[:mobile].gsub(/[^0-9]/, '') if person[:mobile].present?
+    person
   end
 end

--- a/app/controllers/signups_controller.rb
+++ b/app/controllers/signups_controller.rb
@@ -5,7 +5,11 @@ class SignupsController < ApplicationController
 
   def create
     begin
-      person = nation_builder_client.call(:people, :push, person: { email: email_param })
+      person_params = { email: email_param }
+      if (params[:phone])
+        person_params[:mobile] = phone_param
+      end
+      person = nation_builder_client.call(:people, :push, person: person_params)
       person_id = person['person']['id']
       nation_builder_client.call(:people, :tag_person, { id: person_id, tagging: { tag: tags_param }} )
       redirect_back flash: { success: 'Thank you for signing up.' }, fallback_location: root_path
@@ -29,5 +33,9 @@ protected
 
   def email_param
     params[:email].to_s.downcase.strip
+  end
+
+  def phone_param
+    params[:phone].gsub(/[^0-9]/, '')
   end
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -17,6 +17,7 @@
 #  background_image_url :string
 #  meta_title           :string
 #  meta_desc            :string
+#  form_collect_phone   :boolean          default(FALSE), not null
 #
 # Indexes
 #

--- a/app/views/pages/_signup.html.erb
+++ b/app/views/pages/_signup.html.erb
@@ -1,6 +1,10 @@
+<% collect_phone ||= false %>
 <%= form_tag signup_path do %>
   <div class='form__group'>
     <%= email_field_tag :email, params[:email], class: 'input signup__email', placeholder: 'E-mail', required: true %>
+    <% if @page.form_collect_phone %>
+      <%= phone_field_tag :phone, params[:phone], class: 'input signup__phone', placeholder: 'Mobile phone', required: true %>
+    <% end %>
     <%= hidden_field_tag 'tags', @page.form_tags %>
     <%= submit_tag 'Submit', class: 'button button-primary' %>
   </div>

--- a/app/views/pages/_signup.html.erb
+++ b/app/views/pages/_signup.html.erb
@@ -1,9 +1,9 @@
-<% collect_phone ||= false %>
+<% person_params = params[:person] || {} %>
 <%= form_tag signup_path do %>
   <div class='form__group'>
-    <%= email_field_tag :email, params[:email], class: 'input signup__email', placeholder: 'E-mail', required: true %>
-    <% if @page.form_collect_phone %>
-      <%= phone_field_tag :phone, params[:phone], class: 'input signup__phone', placeholder: 'Mobile phone', required: true %>
+    <%= email_field_tag 'person[email]', person_params[:email], class: 'input signup__email', placeholder: 'E-mail', required: true %>
+    <% if @page.form_collect_phone? %>
+      <%= phone_field_tag 'person[mobile]', person_params[:mobile], class: 'input signup__phone', placeholder: 'Mobile phone', required: true %>
     <% end %>
     <%= hidden_field_tag 'tags', @page.form_tags %>
     <%= submit_tag 'Submit', class: 'button button-primary' %>

--- a/db/migrate/20180801063358_add_phone_to_page_form.rb
+++ b/db/migrate/20180801063358_add_phone_to_page_form.rb
@@ -1,0 +1,5 @@
+class AddPhoneToPageForm < ActiveRecord::Migration[5.1]
+  def change
+    add_column :pages, :form_collect_phone, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180626195841) do
+ActiveRecord::Schema.define(version: 20180801063358) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -84,6 +84,7 @@ ActiveRecord::Schema.define(version: 20180626195841) do
     t.string "background_image_url"
     t.string "meta_title"
     t.string "meta_desc"
+    t.boolean "form_collect_phone", default: false, null: false
     t.index ["slug"], name: "index_pages_on_slug", unique: true
   end
 

--- a/test/fixtures/pages.yml
+++ b/test/fixtures/pages.yml
@@ -17,6 +17,7 @@
 #  background_image_url :string
 #  meta_title           :string
 #  meta_desc            :string
+#  form_collect_phone   :boolean          default(FALSE), not null
 #
 # Indexes
 #

--- a/test/models/page_test.rb
+++ b/test/models/page_test.rb
@@ -17,6 +17,7 @@
 #  background_image_url :string
 #  meta_title           :string
 #  meta_desc            :string
+#  form_collect_phone   :boolean          default(FALSE), not null
 #
 # Indexes
 #


### PR DESCRIPTION
Adds a boolean option to page forms to optionally collect a mobile phone number 
on signups as well as email. To be used for text campaign signups (such as rapid
response strike support).