### PR TITLE
hero text background for added readability

### DIFF
--- a/app/assets/stylesheets/application/_hero.scss
+++ b/app/assets/stylesheets/application/_hero.scss
@@ -2,7 +2,15 @@
 
 .hero {
   margin-bottom: $extra_spacing;
-  h1 { font-weight: bold; }
+  h1 {
+    background-color: $dsa_purple;
+   -webkit-box-decoration-break: clone;
+    box-decoration-break: clone;
+    font-weight: bold;
+    display: inline;
+    padding: 0 0.5rem 0.3rem;
+  }
+
   h1, p { margin: 0; }
 
   &.hero-with-image {


### PR DESCRIPTION
Adds the DSA Purple color as a background to text in the hero component to aid readability of page titles. Fixes #158.

Open to ideas about the padding of the color around the text.

![image](https://user-images.githubusercontent.com/578156/43680508-6ad1df52-97f1-11e8-9473-444a25c83673.png)
