### PR TITLE
Restrict Auth0 source IP addresses

### DIFF
--- a/app/controllers/memberships_controller.rb
+++ b/app/controllers/memberships_controller.rb
@@ -1,13 +1,20 @@
 class MembershipsController < ApplicationController
-  before_action :require_nationbuilder_slug
+  before_action :require_nationbuilder_slug, :require_whitelisted_ip
 
   def check
     email = params[:email].to_s.strip.downcase
-    whitelist = ENV['AUTH0_WHITELIST'].split(',')
+    whitelist = ENV['AUTH0_EMAIL_WHITELIST'].split(',')
     if whitelist.include? email
       render json: { status: :found }, status: :ok
     else
       render json: { status: :not_found }, status: :not_found
     end
+  end
+
+  private
+
+  def require_whitelisted_ip
+    whitelist = ENV['AUTH0_IP_WHITELIST'].split(',')
+    head :forbidden unless whitelist.include? request.remote_ip
   end
 end


### PR DESCRIPTION
Restrict the client IP addresses that are allowed to call membership
action so that only Auth0 can access them.