### PR TITLE
Specify ruby version in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
+ruby '2.4.1'
 
 git_source(:github) do |repo_name|
   repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -318,5 +318,8 @@ DEPENDENCIES
   web-console (>= 3.3.0)
   will_paginate (~> 3.1.0)
 
+RUBY VERSION
+   ruby 2.4.1p111
+
 BUNDLED WITH
    1.16.2


### PR DESCRIPTION
The Readme lists Ruby >= 2.4.0 to run, and I've been running 2.4.1 this whole time (and it works just fine obv). Feels like we should specify our ruby version in the Gemfile, and we could either say `>= 2.4.0` or just specify 1 version. RVM conveniently switches your ruby version when you `cd` into the directory if you specify exactly 1 version, so I opted for that. Happy to use 2.4.0 or another, if that's what y'all are using, but we should probably get on the same one.