### PR TITLE
Open internal links in the same tab

### DIFF
--- a/app/assets/javascripts/active_admin.js.coffee
+++ b/app/assets/javascripts/active_admin.js.coffee
@@ -3,4 +3,5 @@
 #= require trix
 #= require activeadmin/quill_editor/quill
 #= require quill_editor_input
+#= require quill_link
 #= require attachments

--- a/app/assets/javascripts/quill_link.js
+++ b/app/assets/javascripts/quill_link.js
@@ -1,0 +1,22 @@
+// Customize the way Quill generates anchor tags.
+
+class Link extends Quill.import('formats/link') {
+  static create(value) {
+    const node = super.create(value);
+
+    // Default Link adds target="_blank" and rel="noopener noreferrer".
+    // The target opens links in a new tab, making it easier to return
+    // to the site later; noopener offers some protection against
+    // malicious sites redirecting the existing tab; and noreferrer
+    // offers some privacy for the person following the link. None of
+    // these motivations apply to internal links within the site.
+    if(node.href.startsWith(window.location.origin)) {
+      node.removeAttribute('rel');
+      node.removeAttribute('target');
+    }
+
+    return node;
+  }
+}
+
+Quill.register(Link);


### PR DESCRIPTION
Open internal links (links to the site itself) in the same tab.

The Quill editor adds some attributes to the links it creates. While
there are good reasons to add these attributes, none of these reasons
apply to internal links. This change overrides the default Link format
to exclude these attributes from internal links.

Relates to #159.