### PR TITLE
add back s3_url function

### DIFF
--- a/app/assets/javascripts/attachments.js
+++ b/app/assets/javascripts/attachments.js
@@ -2,6 +2,10 @@ $(document).ready(function() {
   // The default caption is misleading, it isn't clear that you can edit
   // the field to set your own caption. Remove the default, which fills
   // in a much nicer "Add a caption..." message.
+  $('.s3_url').each(function(i, form_element) {
+    setupS3UrlField($(form_element));
+    refreshImagePreview($(form_element));
+  });
 });
 
 


### PR DESCRIPTION
Ended up being a function I removed by mistake during the trix gem removal, tested in staging and looks to work

![Capture](https://github.com/eastbaydsa/website/assets/1326564/3416a780-dc94-41b2-b6f3-c547c764b0db)
