### PR TITLE
Adding PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+# Summary
+   Add a clear and concise description of the issues being addressed
+# Solution
+   Provide a detailed account of changes made in this pull request
+# Testing
+   Describe the testing steps needed to test your changes
+


### PR DESCRIPTION
# Description
Adding default PR template to add guidance to PR submission

# Solution
Add PR template doc to main branch will set this by default on all pull requests committed to the repo.